### PR TITLE
feat: update JavaFixture version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.github.nylle</groupId>
             <artifactId>javafixture</artifactId>
-            <version>2.6.1</version>
+            <version>2.9.3</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.1</version>
+            <version>5.9.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.5.1</version>
+            <version>5.9.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/kotlin/com/github/nylle/kotlinfixture/FixtureTest.kt
+++ b/src/test/kotlin/com/github/nylle/kotlinfixture/FixtureTest.kt
@@ -6,7 +6,6 @@ import com.github.nylle.kotlinfixture.testobjects.TestObjectWithGenericConstruct
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.Clock
-import java.util.ArrayList
 import java.util.Optional
 
 
@@ -18,10 +17,8 @@ class FixtureTest {
 
         assertThat(result).isInstanceOf(TestObjectWithGenericConstructor::class.java)
         assertThat(result.value).isInstanceOf(String::class.java)
-        assertThat(result.value).isNotBlank()
+        assertThat(result.value).isNotBlank
         assertThat(result.integer).isInstanceOf(Optional::class.java)
-        assertThat(result.integer).isPresent
-        assertThat(result.integer.get()).isInstanceOf(Integer::class.java)
         assertThat(result.privateField).isNull()
     }
 
@@ -32,8 +29,6 @@ class FixtureTest {
         assertThat(result).isInstanceOf(TestObjectGeneric::class.java)
         assertThat(result.t).isInstanceOf(String::class.java)
         assertThat(result.u).isInstanceOf(Optional::class.java)
-        assertThat(result.u).isPresent
-        assertThat(result.u.get()).isInstanceOf(Integer::class.java)
     }
 
     @TestWithFixture(minCollectionSize = 11, maxCollectionSize = 11, positiveNumbersOnly = true)
@@ -57,8 +52,6 @@ class FixtureTest {
         assertThat(result).isInstanceOf(TestObjectGeneric::class.java)
         assertThat(result.t).isInstanceOf(String::class.java)
         assertThat(result.u).isInstanceOf(Optional::class.java)
-        assertThat(result.u).isPresent()
-        assertThat(result.u.get()).isInstanceOf(Integer::class.java)
     }
 
     @Test

--- a/src/test/kotlin/com/github/nylle/kotlinfixture/SpecimenBuilderTest.kt
+++ b/src/test/kotlin/com/github/nylle/kotlinfixture/SpecimenBuilderTest.kt
@@ -73,15 +73,14 @@ class SpecimenBuilderTest {
 
     @Test
     fun withType() {
-        val sut = SpecimenBuilder(com.github.nylle.javafixture.SpecimenBuilder(object : SpecimenType<TestObjectGeneric<String, Optional<Int>>>(){}, configure()))
+        val sut = SpecimenBuilder(com.github.nylle.javafixture.SpecimenBuilder(object : SpecimenType<TestObjectGeneric<String, Int>>(){}, configure()))
 
         val result = sut
                 .with<Int>(111111)
                 .create()
 
         assertThat(result).isInstanceOf(TestObjectGeneric::class.java)
-        assertThat(result.u).isPresent
-        assertThat(result.u.get()).isEqualTo(111111)
+        assertThat(result.u).isEqualTo(111111)
     }
 
     @Test


### PR DESCRIPTION
Also updates the JUnit dependencies, for the same reason. Since JavaFixture changed the behavior of optionals - they can be empty - the tests are also updated to reflect this.

Refs: KF-3