### PR TITLE
build: update JavaFixture and kotlin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.9.20</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.github.nylle</groupId>
             <artifactId>javafixture</artifactId>
-            <version>2.9.3</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/test/kotlin/com/github/nylle/kotlinfixture/FixtureTest.kt
+++ b/src/test/kotlin/com/github/nylle/kotlinfixture/FixtureTest.kt
@@ -1,6 +1,8 @@
 package com.github.nylle.kotlinfixture
 
 import com.github.nylle.javafixture.annotations.fixture.TestWithFixture
+import com.github.nylle.javafixture.annotations.testcases.TestCase
+import com.github.nylle.javafixture.annotations.testcases.TestWithCases
 import com.github.nylle.kotlinfixture.testobjects.TestObjectGeneric
 import com.github.nylle.kotlinfixture.testobjects.TestObjectWithGenericConstructor
 import org.assertj.core.api.Assertions.assertThat
@@ -100,5 +102,12 @@ class FixtureTest {
         assertThat(result).hasSize(1)
         assertThat(result[0]).hasSize(11)
         assertThat(result[0]).allMatch { x -> x > -1 }
+    }
+
+    @TestWithCases
+    @TestCase(str1 = "abc", str2 = "cba")
+    @TestCase(str1 = "", str2 = "")
+    fun `repeating annotations are supported`(param1: String, param2: String) {
+        assertThat(param1.reversed()).isEqualTo(param2)
     }
 }


### PR DESCRIPTION
This updates syncs up KotlinFixture to the latest Java Fixture version.

Additionally, this bumps the kotlin compiler version to latest. This should not affect downstream clients, as Kotlin produces Java 8 bytecode by default.

The main benefit is that now the use of repeating annotations is possible.